### PR TITLE
Optimize dumping objects by code generating functions to dump objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,4 @@ venv
 
 # Other
 .directory
-
+*.pprof

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -76,3 +76,4 @@ Contributors (chronological)
 - Sabine Maennel `@sabinem <https://github.com/sabinem>`_
 - Victor Varvaryuk `@mindojo-victor <https://github.com/mindojo-victor>`_
 - Jāzeps Baško `@jbasko <https://github.com/jbasko>`_
+- `@podhmo <https://github.com/podhmo>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+2.11.1 (2017-01-08)
++++++++++++++++++++
+
+Bug fixes:
+
+- Allow ``strict`` class Meta option to be overriden by constructor (:issue:`550`). Thanks :user:`douglas-treadwell` for reporting and thanks :user:`podhmo` for the PR.
+
 2.11.0 (2017-01-08)
 +++++++++++++++++++
 

--- a/marshmallow/__init__.py
+++ b/marshmallow/__init__.py
@@ -14,7 +14,7 @@ from marshmallow.decorators import (
 from marshmallow.utils import pprint, missing
 from marshmallow.exceptions import ValidationError
 
-__version__ = '2.11.0'
+__version__ = '2.11.1'
 __author__ = 'Steven Loria'
 
 __all__ = [

--- a/marshmallow/schema.py
+++ b/marshmallow/schema.py
@@ -324,7 +324,7 @@ class BaseSchema(base.SchemaABC):
         """
         pass
 
-    def __init__(self, extra=None, only=(), exclude=(), prefix='', strict=False,
+    def __init__(self, extra=None, only=(), exclude=(), prefix='', strict=None,
                  many=False, context=None, load_only=(), dump_only=(),
                  partial=False):
         # copy declared fields from metaclass
@@ -333,7 +333,7 @@ class BaseSchema(base.SchemaABC):
         self.only = only
         self.exclude = exclude
         self.prefix = prefix
-        self.strict = strict or self.opts.strict
+        self.strict = strict if strict is not None else self.opts.strict
         self.ordered = self.opts.ordered
         self.load_only = set(load_only) or set(self.opts.load_only)
         self.dump_only = set(dump_only) or set(self.opts.dump_only)

--- a/marshmallow/utils.py
+++ b/marshmallow/utils.py
@@ -6,9 +6,11 @@ import collections
 import datetime
 import inspect
 import json
+import os
 import time
 import types
 from calendar import timegm
+from contextlib import contextmanager
 from decimal import Decimal, ROUND_HALF_EVEN, Context, Inexact
 from email.utils import formatdate, parsedate
 from pprint import pprint as py_pprint
@@ -342,3 +344,29 @@ Handles `functools.partial` objects and callable objects.
 
 def if_none(value, default):
     return value if value is not None else default
+
+
+class IndentedSting(object):
+    def __init__(self, indent=4):
+        self.result = []
+        self._indent = indent
+        self.__indents = ['']
+
+    @contextmanager
+    def indent(self):
+        self.__indents.append(self.__indents[-1] + (self._indent * ' '))
+        try:
+            yield
+        finally:
+            self.__indents.pop()
+
+    def __iadd__(self, other):
+        if isinstance(other, IndentedSting):
+            for line in other.result:
+                self.result.append(self.__indents[-1] + line)
+        else:
+            self.result.append(self.__indents[-1] + other)
+        return self
+
+    def __str__(self):
+        return os.linesep.join(self.result)

--- a/performance/benchmark.py
+++ b/performance/benchmark.py
@@ -1,0 +1,125 @@
+from __future__ import print_function, unicode_literals
+
+import cProfile
+import gc
+import timeit
+import time
+
+from marshmallow import Schema, fields, ValidationError, pre_load
+
+
+# Custom validator
+def must_not_be_blank(data):
+    if not data:
+        raise ValidationError('Data not provided.')
+
+
+class AuthorSchema(Schema):
+    class Meta:
+        expect_object = True
+        no_callable_fields = True
+
+    id = fields.Int(dump_only=True)
+    first = fields.Str()
+    last = fields.Str()
+    book_count = fields.Float()
+    age = fields.Float()
+    address = fields.Str()
+    full_name = fields.Method('full_name')
+
+    def full_name(self, obj):
+        return obj.first + ' ' + obj.last
+
+    def format_name(self, author):
+        return "{0}, {1}".format(author.last, author.first)
+
+
+class QuoteSchema(Schema):
+    class Meta:
+        expect_object = True
+        no_callable_fields = True
+
+    id = fields.Int(dump_only=True)
+    author = fields.Nested(AuthorSchema, validate=must_not_be_blank)
+    content = fields.Str(required=True, validate=must_not_be_blank)
+    posted_at = fields.Int(dump_only=True)
+    book_name = fields.Str()
+    page_number = fields.Float()
+    line_number = fields.Float()
+    col_number = fields.Float()
+
+    # Allow client to pass author's full name in request body
+    # e.g. {"author': 'Tim Peters"} rather than {"first": "Tim", "last": "Peters"}
+    @pre_load
+    def process_author(self, data):
+        author_name = data.get('author')
+        if author_name:
+            first, last = author_name.split(' ')
+            author_dict = dict(first=first, last=last)
+        else:
+            author_dict = {}
+        data['author'] = author_dict
+        return data
+
+
+class Author(object):
+    def __init__(self, id, first, last, book_count, age, address):
+        self.id = id
+        self.first = first
+        self.last = last
+        self.book_count = book_count
+        self.age = age
+        self.address = address
+
+
+class Quote(object):
+    def __init__(self, id, author, content, posted_at, book_name, page_number,
+                 line_number, col_number):
+        self.id = id
+        self.author = author
+        self.content = content
+        self.posted_at = posted_at
+        self.book_name = book_name
+        self.page_number = page_number
+        self.line_number = line_number
+        self.col_number = col_number
+
+
+quotes = []
+locations = []
+
+for i in range(20):
+    quotes.append(
+        Quote(i, Author(i, 'Foo', 'Bar', 42, 66, '123 Fake St'),
+              'Hello World', time.time(), 'The World', 34, 3, 70)
+    )
+
+def run_timeit(optimize, profile=False):
+    number = 1000
+    repeat = 5
+    quotes_schema = QuoteSchema(many=True, optimize=optimize)
+    if profile:
+        profile = cProfile.Profile()
+        profile.enable()
+
+    gc.collect()
+    best = min(timeit.repeat(lambda: quotes_schema.dump(quotes),
+                             'gc.enable()',
+                             number=number,
+                             repeat=repeat))
+    if profile:
+        profile.disable()
+        profile.dump_stats('optimized.pprof' if optimize else 'original.pprof')
+
+    usec = best * 1e6 / number
+    return usec
+
+
+optimized_time = run_timeit(True)
+original_time = run_timeit(False)
+
+
+print('Benchmark Result:')
+print('\tOriginal Time: {0:.2f} usec/dump'.format(original_time))
+print('\tOptimized Time: {0:.2f} usec/dump'.format(optimized_time))
+print('\tSpeed up: {0:.2f}x'.format(original_time / optimized_time))

--- a/tasks.py
+++ b/tasks.py
@@ -24,12 +24,21 @@ def test(ctx, watch=False, last_failing=False):
     if int(sys.version_info[0]) < 3:
         args.append('--ignore={0}'.format(os.path.join('tests', 'test_py3')))
     retcode = pytest.main(args)
+    if retcode == 0:
+        os.environ['MARSHMALLOW_OPTIMIZE_SCHEMA'] = 'True'
+        retcode = pytest.main(args)
+    benchmark(ctx)
     sys.exit(retcode)
 
 @task
 def flake(ctx):
     """Run flake8 on codebase."""
     ctx.run('flake8 .', echo=True)
+
+@task
+def benchmark(ctx):
+    """Run benchmarks on codebase."""
+    ctx.run('python performance/benchmark.py', echo=True)
 
 @task
 def clean(ctx):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2048,3 +2048,44 @@ class TestLoadOnly:
         assert 'str_dump_only' not in result.data
         assert 'str_load_only' in result.data
         assert 'str_regular' in result.data
+
+
+class TestStrictDefault:
+
+    class SchemaTrueByMeta(Schema):
+        class Meta:
+            strict = True
+
+    class SchemaFalseByMeta(Schema):
+        class Meta:
+            strict = False
+
+    class SchemaWithoutMeta(Schema):
+        pass
+
+    def test_default(self):
+        assert self.SchemaWithoutMeta().strict is False
+
+    def test_meta_true(self):
+        assert self.SchemaTrueByMeta().strict is True
+
+    def test_meta_false(self):
+        assert self.SchemaFalseByMeta().strict is False
+
+    def test_default_init_true(self):
+        assert self.SchemaWithoutMeta(strict=True).strict is True
+
+    def test_default_init_false(self):
+        assert self.SchemaWithoutMeta(strict=False).strict is False
+
+    def test_meta_true_init_true(self):
+        assert self.SchemaTrueByMeta(strict=True).strict is True
+
+    def test_meta_true_init_false(self):
+        assert self.SchemaTrueByMeta(strict=False).strict is False
+
+    def test_meta_false_init_true(self):
+        assert self.SchemaFalseByMeta(strict=True).strict is True
+
+    def test_meta_false_init_false(self):
+        assert self.SchemaFalseByMeta(strict=False).strict is False


### PR DESCRIPTION
After profiling some of our services running Marshmallow, we noticed that it was
consuming a ton of CPU.  This approach is similar to that of namedtuple in that
we generate python code for dumping objects.  We then fall back to the original,
slower path should anything go wrong.

In the example provided in performance/benchmark.py we see a 13x speedup.  For
some of our internal schemas, this is closer to 20x.

```
Benchmark Result:
	Original Time: 2398.07 usec/dump
	Optimized Time: 171.52 usec/dump
	Speed up: 13.98
```